### PR TITLE
ConcurrentModificationException, if "find()" is called asynchronously multiple times

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>de.adito.picoservice</groupId>
   <artifactId>picoservice</artifactId>
-  <version>1.1.2</version>
+  <version>1.1.3</version>
 
   <name>${project.groupId}:${project.artifactId}</name>
   <description>A minimalist registry for java services using serviceloader</description>

--- a/src/main/java/de/adito/picoservice/DefaultPicoRegistry.java
+++ b/src/main/java/de/adito/picoservice/DefaultPicoRegistry.java
@@ -3,6 +3,7 @@ package de.adito.picoservice;
 import javax.annotation.Nonnull;
 import java.lang.annotation.Annotation;
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
@@ -19,7 +20,7 @@ public class DefaultPicoRegistry implements IPicoRegistry
   protected DefaultPicoRegistry()
   {
     loadedServices = _loadServices();
-    searchedTypeToAnnotatedClassesMap = new HashMap<>();
+    searchedTypeToAnnotatedClassesMap = new ConcurrentHashMap<>();
   }
 
   @Nonnull


### PR DESCRIPTION
If you call the "find()"-Method multiple times from different threads (like NetBeans 9 implicitly does), a ConcurentModificationException is thrown.
We should use a ConcurrentHashMap, because it handels those async calls automatically. 
The performance should not be too bad.
I increased the version to 1.1.3, deployed on our local nexus but not on mvnrepo.